### PR TITLE
Fixed Form Position and removed unnecessary `self.Width` on button click

### DIFF
--- a/samples/HelloDelphiFMX.py
+++ b/samples/HelloDelphiFMX.py
@@ -14,7 +14,7 @@ class HelloForm(Form):
 
     def __init__(self, owner):
         self.SetProps(Caption = "Hello Python", 
-            Position = "poScreenCenter", OnShow = self.__form_show)
+            Position = "ScreenCenter", OnShow = self.__form_show)
 
         self.hello = Label(self)
         self.hello.SetProps(Parent = self, width = 200,
@@ -29,7 +29,6 @@ class HelloForm(Form):
 
     def __button_click(self, sender):
         self.hello.Text = "Thanks!"
-        self.Width = 300
 
 def main():
     Application.Initialize()


### PR DESCRIPTION
`Position = "poScreenCenter"` doesn't work on FMX. It should be `Position = "ScreenCenter"` and then I noticed there is a `self.Width = 300` under the button click that isn't necessary since the Width is already being set on the form show event.